### PR TITLE
Fix for 64-bit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
+MSYSROOT2="$(cd / && pwd -W)" &&
+MSYSROOT="$(echo "$MSYSROOT2" | sed 's/\//\\\\/g')" || {
+	echo "Unable to determine root directory" >&2
+	exit 1
+}
+
 mkdir -p $PWD/build
-CXXFLAGS="-O0 -ggdb"
+CXXFLAGS="-O0 -ggdb -DMSYSROOT=\"$MSYSROOT\" -DMSYSROOT2=\"$MSYSROOT2\""
 g++ $CXXFLAGS -c -o $PWD/build/path_conv.o $PWD/src/path_conv.cpp && \
 g++ $CXXFLAGS -c -o $PWD/build/main.o $PWD/src/main.cpp && \
 g++ -o path_conv_test.exe $PWD/build/path_conv.o $PWD/build/main.o && ./path_conv_test.exe && echo -e "\nGOOD!!!" || echo -e "\nNOT GOOD"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,7 +344,7 @@ int main() {
         total += 1;
         const char *path = it->src;
         const size_t blen = strlen(it->dst)*2 + 10;
-        char *buf = (char*)malloc(blen);
+        char *buf = (char*)malloc(blen + 1);
         litter_buffer(buf, blen);
 
         const char *res = convert(buf, blen, path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,12 +149,21 @@ typedef struct test_data_t {
     bool fail;
 } test_data;
 
+#ifdef MSYSROOT
+#ifndef MSYSROOT2
+#error "Need to define both MSYSROOT and MSYSROOT2, or neither"
+#endif
+#else
+#ifdef MSYSROOT
+#error "Need to define both MSYSROOT and MSYSROOT2, or neither"
+#endif
 #if defined(__MSYS__) && defined(__LP64__)
 #define MSYSROOT "C:\\msys64"
 #define MSYSROOT2 "C:/msys64"
 #else
 #define MSYSROOT "C:\\msys32"
 #define MSYSROOT2 "C:/msys32"
+#endif
 #endif
 
 static const test_data datas[] = {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,59 +149,67 @@ typedef struct test_data_t {
     bool fail;
 } test_data;
 
+#if defined(__MSYS__) && defined(__LP64__)
+#define MSYSROOT "C:\\msys64"
+#define MSYSROOT2 "C:/msys64"
+#else
+#define MSYSROOT "C:\\msys32"
+#define MSYSROOT2 "C:/msys32"
+#endif
+
 static const test_data datas[] = {
     {"-LIBPATH:../lib", "-LIBPATH:../lib", false}
-    ,{"-LIBPATH:../lib:/tmp", "-LIBPATH:..\\lib;C:\\msys32\\tmp", false}
+    ,{"-LIBPATH:../lib:/tmp", "-LIBPATH:..\\lib;" MSYSROOT "\\tmp", false}
     ,{"//Collection:http://tfsserver", "//Collection:http://tfsserver", false}
     ,{"/Collection:http://tfsserver", "/Collection:http://tfsserver", false}
-    ,{"-L'/foo bar/boo' PREFIX='/foo bar/boo'", "-L'C:/msys32/foo bar/boo' PREFIX='/foo bar/boo'", false}
-    ,{"-L'/foo /bar/boo' PREFIX='/foo /bar/boo'", "-L'C:/msys32/foo /bar/boo' PREFIX='/foo /bar/boo'", false}
+    ,{"-L'/foo bar/boo' PREFIX='/foo bar/boo'", "-L'" MSYSROOT2 "/foo bar/boo' PREFIX='/foo bar/boo'", false}
+    ,{"-L'/foo /bar/boo' PREFIX='/foo /bar/boo'", "-L'" MSYSROOT2 "/foo /bar/boo' PREFIX='/foo /bar/boo'", false}
     ,{"C:\\foo\\bar", "C:\\foo\\bar", false} // 0
     ,{"/foo/bar;", "/foo/bar;", false} // 1
     ,{"//foobar", "/foobar", false} // 2
     ,{"//foo\\bar", "/foo/bar", false} // 3
     ,{"//foo/bar", "//foo/bar", false} // 4
     ,{"/c:\\foo\\bar", "c:/foo/bar", false} // 5
-    ,{"foo=/bar", "foo=C:/msys32/bar", false} // 6
-    ,{"-foo,/bar", "-foo,C:/msys32/bar", false} // 7
-    ,{"-I/foo,/bar", "-I/foo,C:/msys32/bar", false} // 8
-    ,{"-I/foo", "-IC:/msys32/foo", false} // 9
-    ,{"-L/foo", "-LC:/msys32/foo", false} // 9
-    ,{"-L'/foo /bar'", "-L'C:/msys32/foo /bar'", false} // 9
-    ,{"-L'/foo bar'", "-L'C:/msys32/foo bar'", false} // 9
-    ,{"'/opt /bin'", "'C:/msys32/opt /bin'", false}
-    ,{"'/opt files/bin'", "'C:/msys32/opt files/bin'", false}
-    ,{"/", "C:/msys32/", false} // 10
+    ,{"foo=/bar", "foo=" MSYSROOT2 "/bar", false} // 6
+    ,{"-foo,/bar", "-foo," MSYSROOT2 "/bar", false} // 7
+    ,{"-I/foo,/bar", "-I/foo," MSYSROOT2 "/bar", false} // 8
+    ,{"-I/foo", "-I" MSYSROOT2 "/foo", false} // 9
+    ,{"-L/foo", "-L" MSYSROOT2 "/foo", false} // 9
+    ,{"-L'/foo /bar'", "-L'" MSYSROOT2 "/foo /bar'", false} // 9
+    ,{"-L'/foo bar'", "-L'" MSYSROOT2 "/foo bar'", false} // 9
+    ,{"'/opt /bin'", "'" MSYSROOT2 "/opt /bin'", false}
+    ,{"'/opt files/bin'", "'" MSYSROOT2 "/opt files/bin'", false}
+    ,{"/", "" MSYSROOT2 "/", false} // 10
     ,{"/..", "/..", false} // 11
     ,{"x:x:/x", "x:x:/x", false} // 12
-    ,{"x::x:/xx", "x;x;C:\\msys32\\xx", false} // 13
+    ,{"x::x:/xx", "x;x;" MSYSROOT "\\xx", false} // 13
     ,{"x::x/z:x", "x;x\\z;x", false} // 14
-    ,{"x::/x z:x", "x;C:\\msys32\\x z;x", false} // 14
-    ,{"'x::/x z:x'", "'x;C:\\msys32\\x z;x'", false} // 14
+    ,{"x::/x z:x", "x;" MSYSROOT "\\x z;x", false} // 14
+    ,{"'x::/x z:x'", "'x;" MSYSROOT "\\x z;x'", false} // 14
     ,{"/dev/null", "nul", false} // 14
     ,{"'/dev/null'", "'nul'", false} // 14
-    ,{"/tmp:/tmp", "C:\\msys32\\tmp;C:\\msys32\\tmp", false} // 14
-    ,{"'/tmp:/tmp'", "'C:\\msys32\\tmp;C:\\msys32\\tmp'", false} // 14
-    ,{"-L'/tmp:/tmp'", "-L'C:\\msys32\\tmp;C:\\msys32\\tmp'", false} // 14
-    ,{"-L/tmp:/tmp", "-LC:\\msys32\\tmp;C:\\msys32\\tmp", false} // 14
-    ,{"'/bin:/Program Files:/lib'", "'C:\\msys32\\usr\\bin;C:\\msys32\\Program Files;C:\\msys32\\lib'", false}
-    ,{"'-L/opt /bin'", "'-LC:/msys32/opt /bin'", false}
+    ,{"/tmp:/tmp", MSYSROOT "\\tmp;" MSYSROOT "\\tmp", false} // 14
+    ,{"'/tmp:/tmp'", "'" MSYSROOT "\\tmp;" MSYSROOT "\\tmp'", false} // 14
+    ,{"-L'/tmp:/tmp'", "-L'" MSYSROOT "\\tmp;" MSYSROOT "\\tmp'", false} // 14
+    ,{"-L/tmp:/tmp", "-L" MSYSROOT "\\tmp;" MSYSROOT "\\tmp", false} // 14
+    ,{"'/bin:/Program Files:/lib'", "'" MSYSROOT "\\usr\\bin;" MSYSROOT "\\Program Files;" MSYSROOT "\\lib'", false}
+    ,{"'-L/opt /bin'", "'-L" MSYSROOT2 "/opt /bin'", false}
     ,{"-w -- INSTALL_ROOT=C:/Test/ports64", "-w -- INSTALL_ROOT=C:/Test/ports64", false} // 15
     ,{"-w -- INSTALL_ROOT=C:\\Test\\ports64", "-w -- INSTALL_ROOT=C:\\Test\\ports64", false} // 16
     ,{"-IC:/Test/ports64", "-IC:/Test/ports64", false} // 17
-    //,{"-g -O2 -I/foo -L/foo PREFIX=/foo", "-g -O2 -IC:/msys32/foo -LC:/msys32/foo PREFIX=C:/msys32/foo", false}
-    //,{"-g -O2 -I/foo -L'/foo bar/boo' PREFIX='/foo bar/boo'", "-g -O2 -IC:/msys32/foo -L'C:/msys32/foo bar/boo' PREFIX='C:/msys32/foo bar/boo'", false}
+    //,{"-g -O2 -I/foo -L/foo PREFIX=/foo", "-g -O2 -I" MSYSROOT2 "/foo -L" MSYSROOT2 "/foo PREFIX=" MSYSROOT2 "/foo", false}
+    //,{"-g -O2 -I/foo -L'/foo bar/boo' PREFIX='/foo bar/boo'", "-g -O2 -I" MSYSROOT2 "/foo -L'" MSYSROOT2 "/foo bar/boo' PREFIX='" MSYSROOT2 "/foo bar/boo'", false}
     ,{"'C:\\foo\\bar'", "'C:\\foo\\bar'", false} // 0
     ,{"'/foo/bar;'", "'/foo/bar;'", false} // 1
     ,{"'//foobar'", "'/foobar'", false} // 2
     ,{"'//foo\\bar'", "'/foo/bar'", false} // 3
     ,{"'//foo/bar'", "'//foo/bar'", false} // 4
     ,{"'/c:\\foo\\bar'", "'c:/foo/bar'", false} // 5
-    ,{"'foo=/bar'", "'foo=C:/msys32/bar'", false} // 6
-    ,{"'-foo,/bar'", "'-foo,C:/msys32/bar'", false} // 7
-    ,{"'-I/foo,/bar'", "'-I/foo,C:/msys32/bar'", false} // 8
-    ,{"'-I/foo'", "'-IC:/msys32/foo'", false} // 9
-    ,{"'/'", "'C:/msys32/'", false} // 10
+    ,{"'foo=/bar'", "'foo=" MSYSROOT2 "/bar'", false} // 6
+    ,{"'-foo,/bar'", "'-foo," MSYSROOT2 "/bar'", false} // 7
+    ,{"'-I/foo,/bar'", "'-I/foo," MSYSROOT2 "/bar'", false} // 8
+    ,{"'-I/foo'", "'-I" MSYSROOT2 "/foo'", false} // 9
+    ,{"'/'", "'" MSYSROOT2 "/'", false} // 10
     ,{"'/..'", "'/..'", false} // 11
     ,{"'x:x:/x'", "'x:x:/x'", false} // 12
     ,{"'x::x:/x'", "'x;x;X:\\'", false} // 13
@@ -214,7 +222,7 @@ static const test_data datas[] = {
     ,{"'x::http://google.ru:x'", "'x;http://google.ru;x'", false} // 8
     ,{"", "", false}
     ,{"''", "''", false}
-    ,{"/usr/local/info:/usr/share/info:/usr/info:", "C:\\msys32\\usr\\local\\info;C:\\msys32\\usr\\share\\info;C:\\msys32\\usr\\info", false}
+    ,{"/usr/local/info:/usr/share/info:/usr/info:", MSYSROOT "\\usr\\local\\info;" MSYSROOT "\\usr\\share\\info;" MSYSROOT "\\usr\\info", false}
     ,{"as_nl=\r", "as_nl=\r", false}
     ,{"as_nl=\n", "as_nl=\n", false}
     ,{"as_nl= ", "as_nl= ", false}
@@ -223,13 +231,13 @@ static const test_data datas[] = {
     ,{"as_nl=' '", "as_nl=' '", false}
     ,{"C:/Test/ports64", "C:/Test/ports64", false}
     ,{"'C:/Test/ports64'", "'C:/Test/ports64'", false}
-    ,{"('C:/msys32')", "('C:/msys32')", false}
+    ,{"('" MSYSROOT2 "')", "('" MSYSROOT2 "')", false}
     ,{"--implib=./libblah.a", "--implib=./libblah.a", false}
     ,{"'--implib=./libblah.a'", "'--implib=./libblah.a'", false}
     ,{"--implib=../lib/libblah.a", "--implib=../lib/libblah.a", false}
     ,{"'--implib=../lib/libblah.a'", "'--implib=../lib/libblah.a'", false}
-    //,{"    /foo", "    C:/msys32/foo", false}
-    //,{"'    /foo'", "'    C:/msys32/foo'", false}
+    //,{"    /foo", "    " MSYSROOT2 "/foo", false}
+    //,{"'    /foo'", "'    " MSYSROOT2 "/foo'", false}
     //,{"files = '''__init__.py z/codegen.py b/codegen_main.py codegen_docbook.py config.py dbustypes.py parser.py utils.py''' \n", "files = '''__init__.py z/codegen.py b/codegen_main.py codegen_docbook.py config.py dbustypes.py parser.py utils.py''' \n", false}
     ,{
 "import sys\n"
@@ -278,12 +286,12 @@ static const test_data datas[] = {
     ,{"-IC:/msys64/mingw64/include", "-IC:/msys64/mingw64/include", false}
     ,{"E:/msys64/home/Wayne/src/kicad/product/common/gal/opengl/shader.vert", "E:/msys64/home/Wayne/src/kicad/product/common/gal/opengl/shader.vert", false}
     ,{"-//OASIS//DTD", "-//OASIS//DTD", false}
-    ,{"-DCMAKE_INSTALL_PREFIX:PATH=/bb/pkg/mingw", "-DCMAKE_INSTALL_PREFIX:PATH=C:/msys32/bb/pkg/mingw", false}
-    ,{"-DCMAKE_INSTALL_PREFIX=/bb/pkg/mingw", "-DCMAKE_INSTALL_PREFIX=C:/msys32/bb/pkg/mingw", false}
+    ,{"-DCMAKE_INSTALL_PREFIX:PATH=/bb/pkg/mingw", "-DCMAKE_INSTALL_PREFIX:PATH=" MSYSROOT2 "/bb/pkg/mingw", false}
+    ,{"-DCMAKE_INSTALL_PREFIX=/bb/pkg/mingw", "-DCMAKE_INSTALL_PREFIX=" MSYSROOT2 "/bb/pkg/mingw", false}
     ,{"foo:echo /bar/baz", "foo:echo /bar/baz", false}
-    ,{"@/foo/bar", "@C:/msys32/foo/bar", false}
-    ,{"@/foo/bar@", "@C:/msys32/foo/bar@", false}
-    ,{"'@/foo/bar'", "'@C:/msys32/foo/bar'", false}
+    ,{"@/foo/bar", "@" MSYSROOT2 "/foo/bar", false}
+    ,{"@/foo/bar@", "@" MSYSROOT2 "/foo/bar@", false}
+    ,{"'@/foo/bar'", "'@" MSYSROOT2 "/foo/bar'", false}
     ,{"///foo/bar", "//foo/bar", false}
     ,{".:./", ".;.\\", false}
     ,{"..:./", "..;.\\", false}
@@ -291,17 +299,17 @@ static const test_data datas[] = {
     ,{"../:./", "..\\;.\\", false}
     ,{"../aa/:./", "..\\aa\\;.\\", false}
     ,{"../", "../", false}
-    ,{"/foo/bar/", "C:/msys32/foo/bar/", false}
+    ,{"/foo/bar/", "" MSYSROOT2 "/foo/bar/", false}
     ,{"-MExtUtils::ParseXS=process_file", "-MExtUtils::ParseXS=process_file", false}
-    ,{"/foo/bin/../libs", "C:/msys32/foo/bin/../libs", false}
-    ,{"'/foo/bin/../libs'", "'C:/msys32/foo/bin/../libs'", false}
+    ,{"/foo/bin/../libs", "" MSYSROOT2 "/foo/bin/../libs", false}
+    ,{"'/foo/bin/../libs'", "'" MSYSROOT2 "/foo/bin/../libs'", false}
     ,{"ExtUtils::ParseXS::process_file(filename => \"$<\", output => \"$@\", typemap => \"$(PURPLE_PERL_TOP)/common/typemap\");",
       "ExtUtils::ParseXS::process_file(filename => \"$<\", output => \"$@\", typemap => \"$(PURPLE_PERL_TOP)/common/typemap\");", false}
     ,{"-Wl,test/path", "-Wl,test/path", false}
-    ,{"-Wl,/test/path", "-Wl,C:/msys32/test/path", false}
+    ,{"-Wl,/test/path", "-Wl," MSYSROOT2 "/test/path", false}
     ,{"-Wl,--out-implib,64/shlib/libgcc_s.a.tmp", "-Wl,--out-implib,64/shlib/libgcc_s.a.tmp", false}
     ,{"-Wl,--out-implib,_64/shlib/libgcc_s.a.tmp", "-Wl,--out-implib,_64/shlib/libgcc_s.a.tmp", false}
-    ,{"/64/shlib/libgcc_s.a.tmp", "C:/msys32/64/shlib/libgcc_s.a.tmp", false}
+    ,{"/64/shlib/libgcc_s.a.tmp", "" MSYSROOT2 "/64/shlib/libgcc_s.a.tmp", false}
     ,{0, 0, false}
 };
 


### PR DESCRIPTION
This is by necessity still incomplete a fix because it is technically
possible to have an MSys2 installation in other locations than C:\msys32
or C:\msys64, but it will have to do for now.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
