### PR TITLE
Convert the trailing colon to semi-colon while converting paths

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,8 @@ typedef struct test_data_t {
 #endif
 
 static const test_data datas[] = {
-    {"-LIBPATH:../lib", "-LIBPATH:../lib", false}
+    {"/usr/lib:/var:", MSYSROOT "\\usr\\lib;" MSYSROOT "\\var;", false}
+    ,{"-LIBPATH:../lib", "-LIBPATH:../lib", false}
     ,{"-LIBPATH:../lib:/var", "-LIBPATH:..\\lib;" MSYSROOT "\\var", false}
     ,{"//Collection:http://tfsserver", "//Collection:http://tfsserver", false}
     ,{"/Collection:http://tfsserver", "/Collection:http://tfsserver", false}
@@ -231,7 +232,7 @@ static const test_data datas[] = {
     ,{"'x::http://google.ru:x'", "'x;http://google.ru;x'", false} // 8
     ,{"", "", false}
     ,{"''", "''", false}
-    ,{"/usr/local/info:/usr/share/info:/usr/info:", MSYSROOT "\\usr\\local\\info;" MSYSROOT "\\usr\\share\\info;" MSYSROOT "\\usr\\info", false}
+    ,{"/usr/local/info:/usr/share/info:/usr/info:", MSYSROOT "\\usr\\local\\info;" MSYSROOT "\\usr\\share\\info;" MSYSROOT "\\usr\\info;", false}
     ,{"as_nl=\r", "as_nl=\r", false}
     ,{"as_nl=\n", "as_nl=\n", false}
     ,{"as_nl= ", "as_nl= ", false}

--- a/src/path_conv.cpp
+++ b/src/path_conv.cpp
@@ -633,8 +633,6 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
 
     if (!prev_was_simc) {
         subp_convert(&beg, it, is_url, dst, dstend);
-    } else {
-        *dst -= 1;
     }
 }
 


### PR DESCRIPTION
Previously, trailing colons were stripped which caused some issues,
with texinfo package, where trailing `:` or `;` would mean adding standard
library paths, and striping it causes errors. Logically, converting those
trailing colons to semi-colons seems right rather than stripping them.

See https://github.com/msys2/msys2-runtime/issues/94